### PR TITLE
Simplify start_container Script and Remove Container on Exit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ If you have [Docker](https://www.docker.com/get-started) installed, you can proc
 To start a docker container for Yorlang, run this command in the terminal:
 
 ```
-./bin/start_disposable.sh
+./start_container.sh
 ```
 
 ``N/B``: You might have permission problems on a Unix, please visit the following [link](https://askubuntu.com/questions/409025/permission-denied-when-running-sh-scripts) to resolve potential file permission issues.

--- a/start_container.sh
+++ b/start_container.sh
@@ -2,9 +2,7 @@
 
 IMAGE_NAME="yorlang_playground"
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-
-ROOT="$(dirname "${SCRIPT_DIR}")"
+ROOT="$( pwd )"
 
 if [[ "$(docker images -q ${IMAGE_NAME}:latest 2> /dev/null)" == "" ]]; then
     echo " ----- Image Does Not Exist. Building Now. -----"
@@ -17,9 +15,10 @@ echo " ----- Run Application in a Disposable Container -----"
 docker run \
     -i \
     -t \
+    --rm \
     -v ${ROOT}:/src \
     ${IMAGE_NAME} \
     bash
 
-echo " ----- EXITED from disposable container -----"
-echo " ----- Removing Exited Containers. -----"
+echo " ----- EXITED from Disposable Container -----"
+echo " ----- REMOVED Exited Container -----"


### PR DESCRIPTION
Changed the folder of `start_container` script thus enabling the simplification of the script.

Removing the container on exit cleans up the developers system thus avoiding the build up of stopped containers and saving PC storage space.