### PR TITLE
feat: add aago helper function

### DIFF
--- a/src/helperise/datetime_helpers/aago.js
+++ b/src/helperise/datetime_helpers/aago.js
@@ -1,0 +1,24 @@
+/**
+ * 
+ * @param {[ number, number, number, number, number, number, number ]} args year, month, day, hours, minutes, seconds, and milliseconds
+ * 
+ * @returns {[ number, number, number, number, number, number, number ]} [ year, month, day, hours, minutes, seconds, milliseconds ]
+ */
+function aago(args) {
+    if (args instanceof Array) {
+        const d = new Date(...args);
+        return [ 
+            d.getFullYear(), 
+            d.getMonth() + 1, 
+            d.getDate(), 
+            d.getHours(), 
+            d.getMinutes(), 
+            d.getSeconds(), 
+            d.getMilliseconds()
+        ];
+    } 
+    
+    throw new Error('Yorlang system error');
+}
+
+module.exports = aago;

--- a/src/helperise/datetime_helpers/aago.js
+++ b/src/helperise/datetime_helpers/aago.js
@@ -5,7 +5,8 @@
  * @returns {[ number, number, number, number, number, number, number ]} [ year, month, day, hours, minutes, seconds, milliseconds ]
  */
 function aago(args) {
-    if (args instanceof Array) {
+    args = (args || []);
+    if (Array.isArray(args)) {
         const d = new Date(...args);
         return [ 
             d.getFullYear(), 
@@ -16,9 +17,8 @@ function aago(args) {
             d.getSeconds(), 
             d.getMilliseconds()
         ];
-    } 
-    
-    throw new Error('Yorlang system error');
+    }
+    throw new Error("Yorlang system error: arguments[0] should be Array");
 }
 
 module.exports = aago;

--- a/src/helperise/registeredHelperIse.js
+++ b/src/helperise/registeredHelperIse.js
@@ -3,5 +3,6 @@ helperIseDeclarations["ka"] = require("./array_helpers/ka.js");
 helperIseDeclarations["siLetaNla"] = require("./string_helpers/si_leta_nla.js");
 helperIseDeclarations["siLetaKekere"] = require("./string_helpers/si_leta_kekere.js");
 helperIseDeclarations["teSibi"] = require("./input_output/tesibi.js");
+helperIseDeclarations["aago"] = require("./datetime_helpers/aago.js");
 
 module.exports = helperIseDeclarations;

--- a/src/tests/helperise/datetime_helpers/aago.test.js
+++ b/src/tests/helperise/datetime_helpers/aago.test.js
@@ -1,0 +1,37 @@
+const aago = require("../../../helperise/datetime_helpers/aago.js");
+
+describe("Aago Test suite", () => {
+    test("It should return current date", () => {
+        const d = new Date();
+        const aagoArr = aago();
+        expect(aagoArr[0]).toBe(d.getFullYear());
+        expect(aagoArr[1]).toBe(d.getMonth() + 1)
+        expect(aagoArr[2]).toBe(d.getDate()) 
+        expect(aagoArr[3]).toBe(d.getHours())
+        expect(aagoArr[4]).toBe(d.getMinutes()) 
+        expect(aagoArr[5]).toBe(d.getSeconds())
+    });
+
+    test("It should return year, month and day", () => {
+        const d = new Date(2017, 11, 30);
+        const aagoArr = aago([2017, 11, 30]);
+        expect(aagoArr[0]).toBe(d.getFullYear());
+        expect(aagoArr[1]).toBe(d.getMonth() + 1)
+        expect(aagoArr[2]).toBe(d.getDate()) 
+        expect(aagoArr[3]).toBe(d.getHours())
+        expect(aagoArr[4]).toBe(d.getMinutes()) 
+        expect(aagoArr[5]).toBe(d.getSeconds())
+    });
+
+    test("It should return hour, minutes, seconds, and milliseconds", () => {
+        const d = new Date(2017, 11, 30, 9, 15, 15, 150);
+        const aagoArr = aago([2017, 11, 30, 9, 15, 15, 150]);
+        expect(aagoArr[0]).toBe(d.getFullYear());
+        expect(aagoArr[1]).toBe(d.getMonth() + 1)
+        expect(aagoArr[2]).toBe(d.getDate()) 
+        expect(aagoArr[3]).toBe(d.getHours())
+        expect(aagoArr[4]).toBe(d.getMinutes()) 
+        expect(aagoArr[5]).toBe(d.getSeconds())
+        expect(aagoArr[6]).toBe(d.getMilliseconds())
+    });
+});


### PR DESCRIPTION
The `aago()` function returns an array of `[ year, month, day, hours, minutes, seconds, milliseconds ]` representing a Date instance.

I think this can be a yorlang's date representation, pending when objects are added to the language.