### PR TITLE
Space removed from <html> tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html >
+<html>
 <head>
   <!-- Site made with Mobirise Website Builder v4.8.6, # -->
   <meta charset="UTF-8">


### PR DESCRIPTION
Following w3c standard, the `<html>` tag is not supposed to contain white space.
although this does not affect anything