### PR TITLE
fix: make sure month is 1-based rather than 0-based

### DIFF
--- a/src/helperise/datetime_helpers/aago.js
+++ b/src/helperise/datetime_helpers/aago.js
@@ -4,16 +4,23 @@
  * @returns {[ number, number, number, number, number, number, number ]} [ year, month, day, hours, minutes, seconds, milliseconds ]
  */
 function aago (args) {
-    const date = new Date();
-    return [
-        date.getFullYear(),
-        date.getMonth() + 1,
-        date.getDate(),
-        date.getHours(),
-        date.getMinutes(),
-        date.getSeconds(),
-        date.getMilliseconds(),
-    ];
+    if (Array.isArray(args)) {
+        // make sure an array can be passed in as the first param
+        if (Array.isArray(args[0])) args = args[0];
+        if (args[1]) --args[1]; // make sure month is 1-based rather than 0-based
+        const date = new Date(...args);
+        return [
+            date.getFullYear(),
+            date.getMonth() + 1,
+            date.getDate(),
+            date.getHours(),
+            date.getMinutes(),
+            date.getSeconds(),
+            date.getMilliseconds(),
+        ];
+    }
+
+    throw new Error("Yorlang system error: arguments[0] should be Array");
 }
 
 module.exports = aago;

--- a/src/helperise/datetime_helpers/aago.js
+++ b/src/helperise/datetime_helpers/aago.js
@@ -7,11 +7,11 @@ function aago (args) {
     if (Array.isArray(args)) {
         // make sure an array can be passed in as the first param
         if (Array.isArray(args[0])) args = args[0];
-        if (args[1]) --args[1]; // make sure month is 1-based rather than 0-based
+        if (args[1]) --args[1]; // convert month value to 0-based index for JavaScript
         const date = new Date(...args);
         return [
             date.getFullYear(),
-            date.getMonth() + 1,
+            date.getMonth() + 1, // increment 0-based index for use by Yorlang
             date.getDate(),
             date.getHours(),
             date.getMinutes(),

--- a/src/tests/helperise/datetime_helpers/aago.test.js
+++ b/src/tests/helperise/datetime_helpers/aago.test.js
@@ -38,4 +38,40 @@ describe("Aago Test suite", () => {
     test("It should fail to return date because the yorlang system fails to pass it an array as parameter", () => {
         expect(() => aago()).toThrow();
     });
+
+    describe('Array as First Argument', () => {
+        test("It should return current date", () => {
+            const date = new Date();
+            const aagoList = aago([[]]);
+            expect(aagoList[0]).toBe(date.getFullYear());
+            expect(aagoList[1]).toBe(date.getMonth() + 1)
+            expect(aagoList[2]).toBe(date.getDate()) 
+            expect(aagoList[3]).toBe(date.getHours())
+            expect(aagoList[4]).toBe(date.getMinutes()) 
+            expect(aagoList[5]).toBe(date.getSeconds())
+        });
+
+        test("It should return year, month and day", () => {
+            const date = new Date(2017, 11, 30);
+            const aagoList = aago([[2017, 11, 30]]);
+            expect(aagoList[0]).toBe(date.getFullYear());
+            expect(aagoList[1]).toBe(date.getMonth())
+            expect(aagoList[2]).toBe(date.getDate()) 
+            expect(aagoList[3]).toBe(date.getHours())
+            expect(aagoList[4]).toBe(date.getMinutes()) 
+            expect(aagoList[5]).toBe(date.getSeconds())
+        });
+
+        test("It should return hour, minutes, seconds, and milliseconds", () => {
+            const date = new Date(2017, 11, 30, 9, 15, 15, 150);
+            const aagoList = aago([[2017, 11, 30, 9, 15, 15, 150]]);
+            expect(aagoList[0]).toBe(date.getFullYear());
+            expect(aagoList[1]).toBe(date.getMonth())
+            expect(aagoList[2]).toBe(date.getDate()) 
+            expect(aagoList[3]).toBe(date.getHours())
+            expect(aagoList[4]).toBe(date.getMinutes()) 
+            expect(aagoList[5]).toBe(date.getSeconds())
+            expect(aagoList[6]).toBe(date.getMilliseconds())
+        });
+    })
 });

--- a/src/tests/helperise/datetime_helpers/aago.test.js
+++ b/src/tests/helperise/datetime_helpers/aago.test.js
@@ -11,4 +11,31 @@ describe("Aago Test suite", () => {
         expect(aagoList[4]).toBe(date.getMinutes()) 
         expect(aagoList[5]).toBe(date.getSeconds())
     });
+
+    test("It should return year, month and day", () => {
+        const date = new Date(2017, 11, 30);
+        const aagoList = aago([2017, 11, 30]);
+        expect(aagoList[0]).toBe(date.getFullYear());
+        expect(aagoList[1]).toBe(date.getMonth())
+        expect(aagoList[2]).toBe(date.getDate()) 
+        expect(aagoList[3]).toBe(date.getHours())
+        expect(aagoList[4]).toBe(date.getMinutes()) 
+        expect(aagoList[5]).toBe(date.getSeconds())
+    });
+
+    test("It should return hour, minutes, seconds, and milliseconds", () => {
+        const date = new Date(2017, 11, 30, 9, 15, 15, 150);
+        const aagoList = aago([2017, 11, 30, 9, 15, 15, 150]);
+        expect(aagoList[0]).toBe(date.getFullYear());
+        expect(aagoList[1]).toBe(date.getMonth())
+        expect(aagoList[2]).toBe(date.getDate()) 
+        expect(aagoList[3]).toBe(date.getHours())
+        expect(aagoList[4]).toBe(date.getMinutes()) 
+        expect(aagoList[5]).toBe(date.getSeconds())
+        expect(aagoList[6]).toBe(date.getMilliseconds())
+    });
+
+    test("It should fail to return date because the yorlang system fails to pass it an array as parameter", () => {
+        expect(() => aago()).toThrow();
+    });
 });


### PR DESCRIPTION
This PR makes sure the aago helper function accepts and returns 1-based month values. E.g. 1 => January, instead of 0 => January like JavaScript does. 

This helps save a lot of confusion.