### PR TITLE
feat: add yipo helper function to return a random number #53

### DIFF
--- a/src/helperise/random_helpers/yipo.js
+++ b/src/helperise/random_helpers/yipo.js
@@ -1,0 +1,26 @@
+/**
+ * Returns a random number between two values (0 -> 1 by default)
+ * - If only one argument is specified, that will become the maximum range, with 0 as the minimum.
+ * - If two arguments are specified, the first will be the minimum, and the second will be the maximum.
+ *
+ * @returns {number}
+ */
+function yipo (args) {
+    if (Array.isArray(args)) {
+        let [ min, max, ] = args;
+        min = Number(min) || 0;
+        max = Number(max) || 0;
+
+        if (min && !max) {
+            max = min;
+            min = 0;
+        }
+
+        if (!max) max = 1;
+
+        return min + (Math.random() * (max - min));
+    }
+    throw new Error("Yorlang system error");
+}
+
+module.exports = yipo;

--- a/src/helperise/registeredHelperIse.js
+++ b/src/helperise/registeredHelperIse.js
@@ -6,5 +6,6 @@ helperIseDeclarations["waNinu"] = require("./string_helpers/wa_ni_nu.js");
 helperIseDeclarations["fiRopo"] = require("./string_helpers/fi_ro_po.js");
 helperIseDeclarations["teSibi"] = require("./input_output/tesibi.js");
 helperIseDeclarations["aago"] = require("./datetime_helpers/aago.js");
+helperIseDeclarations["yipo"] = require("./random_helpers/yipo.js");
 
 module.exports = helperIseDeclarations;

--- a/src/tests/helperise/random_helpers/yipo.test.js
+++ b/src/tests/helperise/random_helpers/yipo.test.js
@@ -1,0 +1,24 @@
+const yipo = require("../../../helperise/random_helpers/yipo.js");
+
+describe("Yipo Test suite", () => {
+    test("It should return a random number between 0 and 1", () => {
+        for (let i = 1; i <= 5; i++) {
+            expect(yipo([])).toBeGreaterThan(0)
+            expect(yipo([])).toBeLessThan(1)
+        }
+    });
+
+    test("It should return a random number between 1 and 2", () => {
+        for (let i = 1; i <= 5; i++) {
+            expect(yipo([1, 2])).toBeGreaterThan(1)
+            expect(yipo([1, 2])).toBeLessThan(2)
+        }
+    });
+
+    test("It should return a random number between 0 and 7", () => {
+        for (let i = 1; i <= 5; i++) {
+            expect(yipo([7])).toBeGreaterThan(0)
+            expect(yipo([7])).toBeLessThan(7)
+        }
+    });
+});


### PR DESCRIPTION
Fixes #53 

```js
yipo() // will return a random number between 0 and 1
yipo(5) // will return a random number between 0 and 5
yipo(5, 10) // will return a random number between 5 and 10
```