### PR TITLE
feat: ensure jeki and terminator are not compulsory in fun's increment

### DIFF
--- a/src/parsers/keywordnodes/kwnodefun.js
+++ b/src/parsers/keywordnodes/kwnodefun.js
@@ -26,7 +26,7 @@ class KwNodeFun extends BaseNode {
         node.condition = bracketExpressionNl.getNode.call(this, false, false);
 
         this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
-        node.increment = kwNodeJeki.getNode.call(this);
+        node.increment = kwNodeJeki.getNode.call(this, { isTerminatorOptional: true, isJekiOptional: true, });
 
         if (KwNodeFun.isInValidFunIncrementStatement(node)) {
             this.throwError(feedbackMessages.funIncrementAndDecrementMsg());

--- a/src/parsers/keywordnodes/kwnodejeki.js
+++ b/src/parsers/keywordnodes/kwnodejeki.js
@@ -4,8 +4,10 @@ const variableNl = require("../nodeLiterals/variablenl.js");
 const feedbackMessages = require("../../feedbackMessages.js");
 
 class KwNodeJeki extends BaseNode {
-    getNode () {
-        this.skipKeyword(constants.KW.JEKI);
+    getNode (opts) {
+        opts = opts || { isTerminatorOptional: false, isJekiOptional: false, };
+
+        this.skipKeyword(constants.KW.JEKI, opts.isJekiOptional);
 
         const node = {};
         node.operation = constants.SYM.ASSIGN;
@@ -14,7 +16,7 @@ class KwNodeJeki extends BaseNode {
         node.left = (varNode.operation === constants.GET_JEKI) ? varNode.name : varNode;
         this.skipOperator(constants.SYM.ASSIGN);
         node.right = this.parseExpression();
-        this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
+        this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR, opts.isTerminatorOptional);
 
         return node;
     }

--- a/src/parsers/parser.js
+++ b/src/parsers/parser.js
@@ -45,8 +45,14 @@ class Parser {
         return token && token.type === constants.KEYWORD && (token.value === kw);
     }
 
-    skipPunctuation (punc) {
+    /**
+     * ignores the next token if its value is a specific punctuation character
+     * @param {string} punc the char to be ignored e.g. semi-colon ";"
+     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a punctuation character
+     */
+    skipPunctuation (punc, isOptional = false) {
         if (this.isNextTokenPunctuation(punc)) this.lexer().next();
+        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
@@ -55,8 +61,14 @@ class Parser {
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
-    skipKeyword (kw) {
+    /**
+     * ignores the next token if its value is a specific keyword
+     * @param {string} kw the keyword to be ignored e.g. jeki
+     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a keyword
+     */
+    skipKeyword (kw, isOptional = false) {
         if (this.isNextTokenKeyword(kw)) this.lexer().next();
+        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
@@ -186,12 +198,14 @@ class Parser {
     parseAst () {
         const token = this.lexer().peek();
 
+        // check if the token's value is a keyword
         if (kwnodes[token.value]) {
             const kwNode = kwnodes[token.value];
             if (kwNode instanceof BaseNode) return kwNode.getNode.call(this); // call the method getNode in kwNode object like an extension function to the Parser class
             else throw new Error(feedbackMessages.baseNodeType(kwNode));
         }
 
+        // check if the token's type is a variable
         if (token.type === constants.VARIABLE) { // then a function call is expected
             const callIseNodeLiteral = nodeLiterals[constants.CALL_ISE];
             if (callIseNodeLiteral instanceof BaseNode) return callIseNodeLiteral.getNode.call(this);

--- a/src/tests/parsers/keywordnodes/kwnodefun.test.js
+++ b/src/tests/parsers/keywordnodes/kwnodefun.test.js
@@ -7,6 +7,52 @@ const Parser = require("../../../parsers/parser.js");
 const lexer = require("../../../lexer.js");
 const InputStream = require("../../../inputstream.js");
 const constants = require("../../../constants.js");
+const expectedNode = {
+    body: [],
+    condition: {
+        left: {
+            name: "i",
+            operation: constants.GET_JEKI,
+        },
+        operation: constants.SYM.L_THAN,
+        right: {
+            left: null,
+            operation: null,
+            right: null,
+            value: 10,
+        },
+        value: null,
+    },
+    increment: {
+        left: "i",
+        operation: constants.SYM.ASSIGN,
+        right: {
+            left: {
+                name: "i",
+                operation: constants.GET_JEKI,
+            },
+            operation: constants.SYM.PLUS,
+            right: {
+                left: null,
+                operation: null,
+                right: null,
+                value: 1,
+            },
+            value: null,
+        },
+    },
+    init: {
+        left: "i",
+        operation: constants.SYM.ASSIGN,
+        right: {
+            left: null,
+            operation: null,
+            right: null,
+            value: 0,
+        },
+    },
+    operation: constants.KW.FUN,
+};
 
 describe("KwNodeFun test suite", () => {
     let parser;
@@ -18,53 +64,18 @@ describe("KwNodeFun test suite", () => {
     test("it should return a valid fun node", () => {
         parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {}`;
 
-        const expectedNode = {
-            body: [],
-            condition: {
-                left: {
-                    name: "i",
-                    operation: constants.GET_JEKI,
-                },
-                operation: constants.SYM.L_THAN,
-                right: {
-                    left: null,
-                    operation: null,
-                    right: null,
-                    value: 10,
-                },
-                value: null,
-            },
-            increment: {
-                left: "i",
-                operation: constants.SYM.ASSIGN,
-                right: {
-                    left: {
-                        name: "i",
-                        operation: constants.GET_JEKI,
-                    },
-                    operation: constants.SYM.PLUS,
-                    right: {
-                        left: null,
-                        operation: null,
-                        right: null,
-                        value: 1,
-                    },
-                    value: null,
-                },
-            },
-            init: {
-                left: "i",
-                operation: constants.SYM.ASSIGN,
-                right: {
-                    left: null,
-                    operation: null,
-                    right: null,
-                    value: 0,
-                },
-            },
-            operation: constants.KW.FUN,
-        };
+        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
+    });
 
+    test("it should return a valid fun node (without jeki in increment)", () => {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1;) {}`;
+
+        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
+    });
+
+    test("it should return a valid fun node (without jeki and terminator in increment)", () => {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1) {}`;
+        
         expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
     });
 


### PR DESCRIPTION
Currently, the syntax for `fun` is:

```js
fún (jeki i = 1; i <= 5; jeki i = i + 1;) {
    sọpé yipo(7);
}
```

The `jeki` beginning the `increment` section of `fun` i.e. `jeki i = i + 1;` and its ending semi-colon are somewhat redundant.

This PR helps fix that, by ensuring they are optional, and adding backward compatibility, so it can now be written as:

```js
fún (jeki i = 1; i <= 5; i = i + 1) {
    sọpé yipo(7);
}
```