### PR TITLE
No terminator in increment section of "fun"

### DIFF
--- a/src/parsers/keywordnodes/kwnodefun.js
+++ b/src/parsers/keywordnodes/kwnodefun.js
@@ -26,7 +26,7 @@ class KwNodeFun extends BaseNode {
         node.condition = bracketExpressionNl.getNode.call(this, false, false);
 
         this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
-        node.increment = kwNodeJeki.getNode.call(this, { isTerminatorOptional: true, isJekiOptional: true, });
+        node.increment = kwNodeJeki.getNode.call(this, { noTerminator: true, });
 
         if (KwNodeFun.isInValidFunIncrementStatement(node)) {
             this.throwError(feedbackMessages.funIncrementAndDecrementMsg());

--- a/src/parsers/keywordnodes/kwnodefun.js
+++ b/src/parsers/keywordnodes/kwnodefun.js
@@ -26,7 +26,7 @@ class KwNodeFun extends BaseNode {
         node.condition = bracketExpressionNl.getNode.call(this, false, false);
 
         this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
-        node.increment = kwNodeJeki.getNode.call(this);
+        node.increment = kwNodeJeki.getNode.call(this, { isTerminatorOptional: true, isJekiOptional: true, });
 
         if (KwNodeFun.isInValidFunIncrementStatement(node)) {
             this.throwError(feedbackMessages.funIncrementAndDecrementMsg());

--- a/src/parsers/keywordnodes/kwnodefun.js
+++ b/src/parsers/keywordnodes/kwnodefun.js
@@ -26,7 +26,7 @@ class KwNodeFun extends BaseNode {
         node.condition = bracketExpressionNl.getNode.call(this, false, false);
 
         this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
-        node.increment = kwNodeJeki.getNode.call(this, { noTerminator: true, });
+        node.increment = kwNodeJeki.getNode.call(this, { shouldExpectTerminator: false, });
 
         if (KwNodeFun.isInValidFunIncrementStatement(node)) {
             this.throwError(feedbackMessages.funIncrementAndDecrementMsg());

--- a/src/parsers/keywordnodes/kwnodejeki.js
+++ b/src/parsers/keywordnodes/kwnodejeki.js
@@ -5,9 +5,9 @@ const feedbackMessages = require("../../feedbackMessages.js");
 
 class KwNodeJeki extends BaseNode {
     getNode (opts) {
-        opts = opts || { isTerminatorOptional: false, isJekiOptional: false, };
+        opts = opts || { noTerminator: false, };
 
-        this.skipKeyword(constants.KW.JEKI, opts.isJekiOptional);
+        this.skipKeyword(constants.KW.JEKI);
 
         const node = {};
         node.operation = constants.SYM.ASSIGN;
@@ -16,7 +16,7 @@ class KwNodeJeki extends BaseNode {
         node.left = (varNode.operation === constants.GET_JEKI) ? varNode.name : varNode;
         this.skipOperator(constants.SYM.ASSIGN);
         node.right = this.parseExpression();
-        this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR, opts.isTerminatorOptional);
+        if (!opts.noTerminator) this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
 
         return node;
     }

--- a/src/parsers/keywordnodes/kwnodejeki.js
+++ b/src/parsers/keywordnodes/kwnodejeki.js
@@ -4,8 +4,8 @@ const variableNl = require("../nodeLiterals/variablenl.js");
 const feedbackMessages = require("../../feedbackMessages.js");
 
 class KwNodeJeki extends BaseNode {
-    getNode (opts) {
-        opts = opts || { noTerminator: false, };
+    getNode (config) {
+        config = config || { shouldExpectTerminator: true, };
 
         this.skipKeyword(constants.KW.JEKI);
 
@@ -16,7 +16,7 @@ class KwNodeJeki extends BaseNode {
         node.left = (varNode.operation === constants.GET_JEKI) ? varNode.name : varNode;
         this.skipOperator(constants.SYM.ASSIGN);
         node.right = this.parseExpression();
-        if (!opts.noTerminator) this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
+        if (config.shouldExpectTerminator) this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
 
         return node;
     }

--- a/src/parsers/keywordnodes/kwnodejeki.js
+++ b/src/parsers/keywordnodes/kwnodejeki.js
@@ -4,8 +4,10 @@ const variableNl = require("../nodeLiterals/variablenl.js");
 const feedbackMessages = require("../../feedbackMessages.js");
 
 class KwNodeJeki extends BaseNode {
-    getNode () {
-        this.skipKeyword(constants.KW.JEKI);
+    getNode (opts) {
+        opts = opts || { isTerminatorOptional: false, isJekiOptional: false, };
+
+        this.skipKeyword(constants.KW.JEKI, opts.isJekiOptional);
 
         const node = {};
         node.operation = constants.SYM.ASSIGN;
@@ -14,7 +16,7 @@ class KwNodeJeki extends BaseNode {
         node.left = (varNode.operation === constants.GET_JEKI) ? varNode.name : varNode;
         this.skipOperator(constants.SYM.ASSIGN);
         node.right = this.parseExpression();
-        this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR);
+        this.skipPunctuation(constants.SYM.STATEMENT_TERMINATOR, opts.isTerminatorOptional);
 
         return node;
     }

--- a/src/parsers/parser.js
+++ b/src/parsers/parser.js
@@ -45,11 +45,6 @@ class Parser {
         return token && token.type === constants.KEYWORD && (token.value === kw);
     }
 
-    /**
-     * ignores the next token if its value is a specific punctuation character
-     * @param {string} punc the char to be ignored e.g. semi-colon ";"
-     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a punctuation character
-     */
     skipPunctuation (punc) {
         if (this.isNextTokenPunctuation(punc)) this.lexer().next();
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
@@ -60,11 +55,6 @@ class Parser {
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
-    /**
-     * ignores the next token if its value is a specific keyword
-     * @param {string} kw the keyword to be ignored e.g. jeki
-     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a keyword
-     */
     skipKeyword (kw) {
         if (this.isNextTokenKeyword(kw)) this.lexer().next();
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
@@ -196,14 +186,12 @@ class Parser {
     parseAst () {
         const token = this.lexer().peek();
 
-        // check if the token's value is a keyword
         if (kwnodes[token.value]) {
             const kwNode = kwnodes[token.value];
             if (kwNode instanceof BaseNode) return kwNode.getNode.call(this); // call the method getNode in kwNode object like an extension function to the Parser class
             else throw new Error(feedbackMessages.baseNodeType(kwNode));
         }
 
-        // check if the token's type is a variable
         if (token.type === constants.VARIABLE) { // then a function call is expected
             const callIseNodeLiteral = nodeLiterals[constants.CALL_ISE];
             if (callIseNodeLiteral instanceof BaseNode) return callIseNodeLiteral.getNode.call(this);

--- a/src/parsers/parser.js
+++ b/src/parsers/parser.js
@@ -50,9 +50,8 @@ class Parser {
      * @param {string} punc the char to be ignored e.g. semi-colon ";"
      * @param {boolean} isOptional ensures it's not compulsory the next token contains such a punctuation character
      */
-    skipPunctuation (punc, isOptional = false) {
+    skipPunctuation (punc) {
         if (this.isNextTokenPunctuation(punc)) this.lexer().next();
-        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
@@ -66,9 +65,8 @@ class Parser {
      * @param {string} kw the keyword to be ignored e.g. jeki
      * @param {boolean} isOptional ensures it's not compulsory the next token contains such a keyword
      */
-    skipKeyword (kw, isOptional = false) {
+    skipKeyword (kw) {
         if (this.isNextTokenKeyword(kw)) this.lexer().next();
-        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 

--- a/src/parsers/parser.js
+++ b/src/parsers/parser.js
@@ -45,8 +45,14 @@ class Parser {
         return token && token.type === constants.KEYWORD && (token.value === kw);
     }
 
-    skipPunctuation (punc) {
+    /**
+     * ignores the next token if its value is a specific punctuation character
+     * @param {string} punc the char to be ignored e.g. semi-colon ";"
+     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a punctuation character
+     */
+    skipPunctuation (punc, isOptional = false) {
         if (this.isNextTokenPunctuation(punc)) this.lexer().next();
+        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
@@ -55,8 +61,14 @@ class Parser {
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
-    skipKeyword (kw) {
+    /**
+     * ignores the next token if its value is a specific keyword
+     * @param {string} kw the keyword to be ignored e.g. jeki
+     * @param {boolean} isOptional ensures it's not compulsory the next token contains such a keyword
+     */
+    skipKeyword (kw, isOptional = false) {
         if (this.isNextTokenKeyword(kw)) this.lexer().next();
+        else if (isOptional);
         else this.throwError(feedbackMessages.genericErrorMsg(this.getCurrentTokenValue()));
     }
 
@@ -186,12 +198,14 @@ class Parser {
     parseAst () {
         const token = this.lexer().peek();
 
+        // check if the token's value is a keyword
         if (kwnodes[token.value]) {
             const kwNode = kwnodes[token.value];
             if (kwNode instanceof BaseNode) return kwNode.getNode.call(this); // call the method getNode in kwNode object like an extension function to the Parser class
             else throw new Error(feedbackMessages.baseNodeType(kwNode));
         }
 
+        // check if the token's type is a variable
         if (token.type === constants.VARIABLE) { // then a function call is expected
             const callIseNodeLiteral = nodeLiterals[constants.CALL_ISE];
             if (callIseNodeLiteral instanceof BaseNode) return callIseNodeLiteral.getNode.call(this);

--- a/src/tests/interpreters/inodecallise.test.js
+++ b/src/tests/interpreters/inodecallise.test.js
@@ -156,7 +156,7 @@ describe("INodeCallIse test suite", () => {
                 ${constants.KW.JEKI} b = [1,2,3];
                 ${constants.KW.JEKI} c = 4;
 
-                ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
+                ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1) {
                     ${constants.KW.PADA} i;
                 }
             }
@@ -175,7 +175,7 @@ describe("INodeCallIse test suite", () => {
                 ${constants.KW.SOPE} i;
             }
 
-            ${constants.KW.FUN} (${constants.KW.JEKI} i = 1; i <= 3; ${constants.KW.JEKI} i = i + 1;) { 
+            ${constants.KW.FUN} (${constants.KW.JEKI} i = 1; i <= 3; ${constants.KW.JEKI} i = i + 1) { 
                 output(i);
             }
         `;

--- a/src/tests/interpreters/inodefun.test.js
+++ b/src/tests/interpreters/inodefun.test.js
@@ -20,7 +20,7 @@ describe("INodeFun test suite", () => {
 
     test("it should interprete fun node", () => {
         parser.lexer().inputStream.code = `
-            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1) {
                 ${constants.KW.SOPE} i;
             }
         `;
@@ -33,7 +33,7 @@ describe("INodeFun test suite", () => {
         parser.lexer().inputStream.code = `
             ${constants.KW.JEKI} num = [1,2,3,4,5,6,7,8,9,10];
 
-            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < ka(num); ${constants.KW.JEKI} i = i + 1;) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < ka(num); ${constants.KW.JEKI} i = i + 1) {
                 ${constants.KW.SOPE} num[i];
             }
         `;
@@ -44,9 +44,9 @@ describe("INodeFun test suite", () => {
 
     test("it should interprete nested fun node", () => {
         parser.lexer().inputStream.code = `
-            ${constants.KW.FUN} (${constants.KW.JEKI} i = 1; i < 3; ${constants.KW.JEKI} i = i + 1;) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i = 1; i < 3; ${constants.KW.JEKI} i = i + 1) {
                 ${constants.KW.SOPE} i;
-                ${constants.KW.FUN} (${constants.KW.JEKI} j = 0; j < 2; ${constants.KW.JEKI} j = i + j;) {
+                ${constants.KW.FUN} (${constants.KW.JEKI} j = 0; j < 2; ${constants.KW.JEKI} j = i + j) {
                     ${constants.KW.SOPE} j;
                 }
             }
@@ -58,7 +58,7 @@ describe("INodeFun test suite", () => {
 
     test("it should interprete fun node with kuro keyword", () => {
         parser.lexer().inputStream.code = `
-            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i = 0; i < 10; ${constants.KW.JEKI} i = i + 1) {
                 ${constants.KW.SOPE} i;
                 ${constants.KW.SE} (i == 5) {
                     ${constants.KW.KURO};

--- a/src/tests/parsers/keywordnodes/kwnodefun.test.js
+++ b/src/tests/parsers/keywordnodes/kwnodefun.test.js
@@ -62,33 +62,21 @@ describe("KwNodeFun test suite", () => {
     });
 
     test("it should return a valid fun node", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {}`;
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {}`;
 
-        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
-    });
-
-    test("it should return a valid fun node (without jeki in increment)", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1;) {}`;
-
-        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
-    });
-
-    test("it should return a valid fun node (without jeki and terminator in increment)", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1) {}`;
-        
         expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
     });
 
     test("it should return a valid fun node for nested blocks", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
-            ${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {}
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {}
         }`;
 
         expect(kwNodeFun.getNode.call(parser)).toBeTruthy();
     });
 
     test("it should throw an error when given invalid fun node", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} ${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} ${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {
             ${constants.KW.SOPE} i;
         }`;
 
@@ -98,7 +86,7 @@ describe("KwNodeFun test suite", () => {
     });
 
     test("it should throw an error when given invalid fun increment node", () => {
-        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = j + 1;) {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = j + 1) {
             ${constants.KW.SOPE} i;
         }`;
 

--- a/src/tests/parsers/keywordnodes/kwnodefun.test.js
+++ b/src/tests/parsers/keywordnodes/kwnodefun.test.js
@@ -7,52 +7,6 @@ const Parser = require("../../../parsers/parser.js");
 const lexer = require("../../../lexer.js");
 const InputStream = require("../../../inputstream.js");
 const constants = require("../../../constants.js");
-const expectedNode = {
-    body: [],
-    condition: {
-        left: {
-            name: "i",
-            operation: constants.GET_JEKI,
-        },
-        operation: constants.SYM.L_THAN,
-        right: {
-            left: null,
-            operation: null,
-            right: null,
-            value: 10,
-        },
-        value: null,
-    },
-    increment: {
-        left: "i",
-        operation: constants.SYM.ASSIGN,
-        right: {
-            left: {
-                name: "i",
-                operation: constants.GET_JEKI,
-            },
-            operation: constants.SYM.PLUS,
-            right: {
-                left: null,
-                operation: null,
-                right: null,
-                value: 1,
-            },
-            value: null,
-        },
-    },
-    init: {
-        left: "i",
-        operation: constants.SYM.ASSIGN,
-        right: {
-            left: null,
-            operation: null,
-            right: null,
-            value: 0,
-        },
-    },
-    operation: constants.KW.FUN,
-};
 
 describe("KwNodeFun test suite", () => {
     let parser;
@@ -62,6 +16,53 @@ describe("KwNodeFun test suite", () => {
     });
 
     test("it should return a valid fun node", () => {
+        const expectedNode = {
+            body: [],
+            condition: {
+                left: {
+                    name: "i",
+                    operation: constants.GET_JEKI,
+                },
+                operation: constants.SYM.L_THAN,
+                right: {
+                    left: null,
+                    operation: null,
+                    right: null,
+                    value: 10,
+                },
+                value: null,
+            },
+            increment: {
+                left: "i",
+                operation: constants.SYM.ASSIGN,
+                right: {
+                    left: {
+                        name: "i",
+                        operation: constants.GET_JEKI,
+                    },
+                    operation: constants.SYM.PLUS,
+                    right: {
+                        left: null,
+                        operation: null,
+                        right: null,
+                        value: 1,
+                    },
+                    value: null,
+                },
+            },
+            init: {
+                left: "i",
+                operation: constants.SYM.ASSIGN,
+                right: {
+                    left: null,
+                    operation: null,
+                    right: null,
+                    value: 0,
+                },
+            },
+            operation: constants.KW.FUN,
+        };
+
         parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {}`;
 
         expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);

--- a/src/tests/parsers/keywordnodes/kwnodefun.test.js
+++ b/src/tests/parsers/keywordnodes/kwnodefun.test.js
@@ -7,6 +7,52 @@ const Parser = require("../../../parsers/parser.js");
 const lexer = require("../../../lexer.js");
 const InputStream = require("../../../inputstream.js");
 const constants = require("../../../constants.js");
+const expectedNode = {
+    body: [],
+    condition: {
+        left: {
+            name: "i",
+            operation: constants.GET_JEKI,
+        },
+        operation: constants.SYM.L_THAN,
+        right: {
+            left: null,
+            operation: null,
+            right: null,
+            value: 10,
+        },
+        value: null,
+    },
+    increment: {
+        left: "i",
+        operation: constants.SYM.ASSIGN,
+        right: {
+            left: {
+                name: "i",
+                operation: constants.GET_JEKI,
+            },
+            operation: constants.SYM.PLUS,
+            right: {
+                left: null,
+                operation: null,
+                right: null,
+                value: 1,
+            },
+            value: null,
+        },
+    },
+    init: {
+        left: "i",
+        operation: constants.SYM.ASSIGN,
+        right: {
+            left: null,
+            operation: null,
+            right: null,
+            value: 0,
+        },
+    },
+    operation: constants.KW.FUN,
+};
 
 describe("KwNodeFun test suite", () => {
     let parser;
@@ -18,53 +64,18 @@ describe("KwNodeFun test suite", () => {
     test("it should return a valid fun node", () => {
         parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {}`;
 
-        const expectedNode = {
-            body: [],
-            condition: {
-                left: {
-                    name: "i",
-                    operation: constants.GET_JEKI,
-                },
-                operation: constants.SYM.L_THAN,
-                right: {
-                    left: null,
-                    operation: null,
-                    right: null,
-                    value: 10,
-                },
-                value: null,
-            },
-            increment: {
-                left: "i",
-                operation: constants.SYM.ASSIGN,
-                right: {
-                    left: {
-                        name: "i",
-                        operation: constants.GET_JEKI,
-                    },
-                    operation: constants.SYM.PLUS,
-                    right: {
-                        left: null,
-                        operation: null,
-                        right: null,
-                        value: 1,
-                    },
-                    value: null,
-                },
-            },
-            init: {
-                left: "i",
-                operation: constants.SYM.ASSIGN,
-                right: {
-                    left: null,
-                    operation: null,
-                    right: null,
-                    value: 0,
-                },
-            },
-            operation: constants.KW.FUN,
-        };
+        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
+    });
 
+    test("it should return a valid fun node (without jeki in increment)", () => {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1;) {}`;
+
+        expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
+    });
+
+    test("it should return a valid fun node (without jeki and terminator in increment)", () => {
+        parser.lexer().inputStream.code = `${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; i = i + 1) {}`;
+        
         expect(kwNodeFun.getNode.call(parser)).toEqual(expectedNode);
     });
 

--- a/src/tests/parsers/keywordnodes/kwnodeise.test.js
+++ b/src/tests/parsers/keywordnodes/kwnodeise.test.js
@@ -41,7 +41,7 @@ describe("KwNodeIse test suite", () => {
         parser.lexer().inputStream.code = `${constants.KW.ISE} koOruko(orukoMi) {
             ${constants.KW.JEKI} oruko = orukoMi;
             
-            ${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1;) {
+            ${constants.KW.FUN} (${constants.KW.JEKI} i =0; i < 10; ${constants.KW.JEKI} i = i + 1) {
                 ${constants.KW.SOPE} i;
             }
         


### PR DESCRIPTION
Currently, the syntax for `fun` is:

```js
fún (jeki i = 1; i <= 5; jeki i = i + 1;) {
    sọpé yipo(7);
}
```

The ending semi-colon is somewhat redundant.

This PR helps fix that, by removing support for it, so it should now be written as:

```js
fún (jeki i = 1; i <= 5; jeki i = i + 1) {
    sọpé yipo(7);
}
```