### PR TITLE
Add division by zero check to remainder operator

### DIFF
--- a/src/interpreters/inoderemainder.js
+++ b/src/interpreters/inoderemainder.js
@@ -1,8 +1,13 @@
 const IBase = require("./ibase.js");
+const feedbackMessages = require("../feedbackMessages.js");
 
 class INodeRemainder extends IBase {
     interpreteNode (node) {
-        return this.evaluateNode(node.left) % this.evaluateNode(node.right);
+        const leftNodeValue = this.evaluateNode(node.left);
+        const rightNodeValue = this.evaluateNode(node.right);
+        if (rightNodeValue === 0) this.throwError(feedbackMessages.yorlangArithmeticException());
+
+        return leftNodeValue % rightNodeValue;
     }
 }
 

--- a/src/tests/interpreters/inoderemainder.test.js
+++ b/src/tests/interpreters/inoderemainder.test.js
@@ -17,4 +17,29 @@ describe("IRemainder test suite", () => {
         const node = kwNodeTi.getNode.call(parser);
         expect(iRemainder.interpreteNode.call(new MainInterpreter(), node.right)).toBe(0);
     });
+
+    test("it should calculate remainder with non-zero divisor", () => {
+        let parser = new Parser(new Lexer(new InputStream()));
+        parser.lexer().inputStream.code = `${constants.KW.JEKI} a = 17 % 5;`;
+        const node = kwNodeTi.getNode.call(parser);
+        expect(iRemainder.interpreteNode.call(new MainInterpreter(), node.right)).toBe(2);
+    });
+
+    test("it should throw error for remainder division by zero", () => {
+        let parser = new Parser(new Lexer(new InputStream()));
+        let mainInterpreter = new MainInterpreter();
+        parser.lexer().inputStream.code = `${constants.KW.JEKI} a = 10 % 0;`;
+        const node = kwNodeTi.getNode.call(parser);
+        expect(() => iRemainder.interpreteNode.call(mainInterpreter, node.right)).toThrow();
+    });
+
+    test("it should throw error for remainder with variable divisor equal to zero", () => {
+        let parser = new Parser(new Lexer(new InputStream()));
+        let mainInterpreter = new MainInterpreter();
+        parser.lexer().inputStream.code = `
+            ${constants.KW.JEKI} divisor = 0;
+            ${constants.KW.JEKI} a = 10 % divisor;
+        `;
+        expect(() => mainInterpreter.interpreteProgram()).toThrow();
+    });
 });


### PR DESCRIPTION
Added validation in INodeRemainder.interpreteNode to check for division by zero before performing modulo operation, matching the behavior of the division operator.

Previously, remainder operations with zero divisor (e.g., 10 % 0) would silently return NaN instead of throwing a proper error, leading to confusing bugs when NaN propagated through calculations.

Changes:
- Added rightNodeValue === 0 check before modulo operation
- Throws yorlangArithmeticException() when divisor is zero
- Now consistent with division operator behavior

Added comprehensive test coverage for:
- Normal remainder operations with non-zero divisors
- Direct division by zero (10 % 0)
- Variable divisors equal to zero
- Ensures proper error throwing behavior